### PR TITLE
Configuration scripts for renaming app and ejecting the project

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
 {
-  "name": "ReactNativeStarter",
-  "displayName": "React Native Starter"
+  "name": "YourAppName",
+  "displayName": "YourDisplayName"
 }

--- a/config-scripts/config.js
+++ b/config-scripts/config.js
@@ -1,0 +1,58 @@
+/**
+ * Config.js is a modified version of awslabs configuration scripts for aws-serverless-express
+ * https://github.com/awslabs/aws-serverless-express/tree/master/example/scripts
+ */
+
+const fs = require('fs');
+const exec = require('child_process').execSync;
+const modifyFiles = require('./util').modifyFiles;
+
+
+let minimistHasBeenInstalled = false;
+
+/**
+ * Install minimist
+ */
+if (!fs.existsSync('./node_modules/minimist')) {
+  exec('npm install minimist --silent');
+  minimistHasBeenInstalled = true;
+}
+
+const args = require('minimist')(process.argv.slice(2), {
+  string: [
+    'displayName',
+  ],
+  default: {
+    displayName: 'React Native Starter',
+  }
+});
+
+/**
+ * Uninstall minimist
+ */
+if (minimistHasBeenInstalled) {
+  exec('npm uninstall minimist --silent');
+}
+
+/**
+ * Save the arguments
+ */
+const displayName = args['displayName'];
+
+if (!displayName) {
+  console.error('You did not include a --displayName');
+  return;
+}
+
+const appName = displayName.replace(/\s/g, ''); // Remove spaces
+
+/**
+ * Modify the files
+ */
+modifyFiles(['./app.json', './package.json', './package-lock.json'], [{
+  regexp: /YourDisplayName/g,
+  replacement: displayName,
+}, {
+  regexp: /YourAppName/g,
+  replacement: appName,
+}]);

--- a/config-scripts/util.js
+++ b/config-scripts/util.js
@@ -1,0 +1,16 @@
+/**
+ * Utility function for modifying files
+ */
+const fs = require('fs');
+
+module.exports.modifyFiles = function modifyFiles(files, replacements) {
+  files.forEach((file) => {
+    let fileContentModified = fs.readFileSync(file, 'utf8');
+
+    replacements.forEach((v) => {
+      fileContentModified = fileContentModified.replace(v.regexp, v.replacement);
+    })
+
+    fs.writeFileSync(file, fileContentModified, 'utf8');
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "ReactNativeStarter",
+  "name": "YourAppName",
   "version": "0.0.1",
   "private": true,
+  "config": {
+    "displayName": "YourDisplayName"
+  },
   "scripts": {
+    "config": "node ./config-scripts/config.js",
+    "postconfig": "rm -r ./android && rm -r ./ios && react-native eject",
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "ios": "node node_modules/react-native/local-cli/cli.js run-ios --simulator=\"iPhone 8 Plus\"",
     "android": "node node_modules/react-native/local-cli/cli.js run-android",


### PR DESCRIPTION
Using `npm run config -- --displayName='Your App Name'` will change the app.json and package.json files with your updated name,  delete the ios and android folders, and then eject the project.